### PR TITLE
feat: put dashboards in "Auth" grafana folder

### DIFF
--- a/katalog/pomerium/monitoring/kustomization.yaml
+++ b/katalog/pomerium/monitoring/kustomization.yaml
@@ -11,6 +11,8 @@ resources:
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Auth"
   disableNameSuffixHash: true
 
 configMapGenerator:


### PR DESCRIPTION
Add annotation to put the module's Grafana dashboards inside the "Auth" folder for better organization.