### PR TITLE
feat(dex): harden Dex deployment

### DIFF
--- a/katalog/dex/MAINTENANCE.md
+++ b/katalog/dex/MAINTENANCE.md
@@ -7,7 +7,7 @@ Run the following commands:
 ```bash
 helm repo add dex https://charts.dexidp.io
 helm repo update
-helm template dex dex/dex -n kube-system --set serviceMonitor.enabled=true > dex-built.yml
+helm template dex dex/dex -n kube-system --values MAINTENANCE.values.yaml > dex-built.yml
 ```
 
 With the `dex-built.yml` file, check differences with the current `deploy.yml` file and change accordingly.
@@ -24,6 +24,7 @@ What was customized (what differs from the helm template command):
 - Added interval `30s` to ServiceMonitor
 - Removed secret, since it's custom for each dex deploy
 - Changed the themes and templates with custom branding
+- Added securityContext configuration to be compliant with the `restricted` PSS. You should not see differences in the diff.
 
 ## How to customize the frontend templates
 

--- a/katalog/dex/MAINTENANCE.values.yaml
+++ b/katalog/dex/MAINTENANCE.values.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+serviceMonitor:
+  enabled: true
+securityContext:
+  privileged: false
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop:
+      - ALL

--- a/katalog/dex/deploy.yml
+++ b/katalog/dex/deploy.yml
@@ -26,9 +26,9 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   name: dex
 subjects:
-- kind: ServiceAccount
-  namespace: kube-system
-  name: dex
+  - kind: ServiceAccount
+    namespace: kube-system
+    name: dex
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -48,9 +48,9 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   name: dex
 subjects:
-- kind: ServiceAccount
-  namespace: kube-system
-  name: dex
+  - kind: ServiceAccount
+    namespace: kube-system
+    name: dex
 ---
 apiVersion: v1
 kind: Service
@@ -89,12 +89,25 @@ spec:
       initContainers:
         - name: init-config
           image: busybox:stable
-          command: ['sh', '-c', 'tar -xzvf /web-archive/web.tar.gz -C /app/web/']
+          command:
+            ["sh", "-c", "tar -xzvf /web-archive/web.tar.gz -C /app/web/"]
           volumeMounts:
             - name: dex-web-custom-archive
               mountPath: /web-archive
             - name: dex-web-custom
               mountPath: /app/web
+          securityContext:
+            privileged: false
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
       containers:
         - name: dex
           image: ghcr.io/dexidp/dex:v2.41.1
@@ -122,13 +135,28 @@ spec:
             limits:
               cpu: 250m
               memory: 200Mi
+          securityContext:
+            privileged: false
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: config
               mountPath: /etc/dex/cfg
+              readOnly: true
             - name: dex-web-custom-archive
               mountPath: /web-archive
+              readOnly: true
             - name: dex-web-custom
               mountPath: /app/web
+              readOnly: true
       volumes:
         - name: config
           secret:


### PR DESCRIPTION
Harden security configuration for Dex's deployment to be compatible with `restricted` Pod Security Standards.

Tested on KFD 1.29.4, OIDC login for both Kubernetes API and Ingresses still work as expected with the hardened configuration.