### PR TITLE
feat(pomerium): improve securityContext

### DIFF
--- a/katalog/pomerium/deploy.yml
+++ b/katalog/pomerium/deploy.yml
@@ -6,7 +6,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pomerium
-  labels: 
+  labels:
     app: pomerium
 spec:
   selector:
@@ -73,7 +73,19 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            privileged: false
+            runAsUser: 65532
+            runAsGroup: 65532
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
+            # This tmp mount is needed so we can have readOnlyRootFilesystem: true
+            - name: tmp
+              mountPath: /tmp
             - mountPath: /etc/pomerium/
               name: pomerium-policy
       volumes:
@@ -81,3 +93,5 @@ spec:
             defaultMode: 420
             name: pomerium-policy
           name: pomerium-policy
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
Improve Pomerium's SecurityContext configuration for incresed security. These changes make Pomerium compliant with the `restriceted` PSS.

Tested with KFD 1.29.4 cluster, with SSO enabled. Grafana with JWT works and the other ingresses work too.