### PR TITLE
fix(pomerium): update logo URL for pomerium on Forecastle

### DIFF
--- a/katalog/pomerium/ingress.yml
+++ b/katalog/pomerium/ingress.yml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     forecastle.stakater.com/expose: "true"
     forecastle.stakater.com/appName: "Pomerium"
-    forecastle.stakater.com/icon: "https://pbs.twimg.com/profile_images/1161448498849390592/fJZaKEGR.png"
+    forecastle.stakater.com/icon: "https://raw.githubusercontent.com/pomerium/pomerium/refs/heads/main/ui/dist/apple-touch-icon.png"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
### Summary 💡

Update Pomerium's Icon URL in Forcastle, old URL was not working anymore.

### Description 📝

See summary

### Breaking Changes 💔

None

### Tests performed 🧪

- [ ] Checked that the image renders correctly using the new URL in forecastle's UI.

### Future work 🔧

May be we should have all the needed icons in the distro's repository
