### PR TITLE
feat: update Gangplank to v1.2.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -68,7 +68,7 @@ steps:
       - Render Manifests
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.34.0
+      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.35.0
     environment:
       KUBERNETES_MANIFESTS: pomerium.yml
 
@@ -690,6 +690,107 @@ steps:
         - failure
 
 ---
+name: E2E Tests on kind clusters version 1.35.0
+kind: pipeline
+type: docker
+platform:
+  os: linux
+  arch: amd64
+depends_on:
+  - Linting
+clone:
+  depth: 1
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+environment:
+  # Mise configuration
+  MISE_DATA_DIR: "/mise-data"
+  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+
+  # Cluster configuration
+  KUBE_VERSION: "1.35.0"
+  KUBECONFIG: "kubeconfig-e2e"
+
+  # Tool versions
+  KUBECTL_VERSION: "1.35.0"
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
+
+steps:
+  - name: Create Kind Cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    depends_on:
+      - clone
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    commands:
+      - |
+        mise use kubectl@$${KUBECTL_VERSION} kind@0.31.0
+        eval "$(mise activate bash --shims)"
+      - ./scripts/create-e2e-cluster.sh
+
+  - name: Run E2E Tests
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    depends_on:
+      - Create Kind Cluster
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    commands:
+      - |
+        mise use kubectl@$${KUBECTL_VERSION} kustomize@5.6.0 bats@1.11.0 kapp@0.65.3 envsubst@1.4.3
+        eval "$(mise activate bash --shims)"
+      - ./scripts/run-e2e-tests.sh
+
+  - name: Destroy Kind Cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    depends_on:
+      - Run E2E Tests
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    commands:
+      - |
+        mise use kubectl@${KUBECTL_VERSION} kind@0.31.0
+        eval "$(mise activate bash --shims)"
+      - ./scripts/cleanup-e2e-cluster.sh
+    when:
+      status:
+        - success
+        - failure
+
+---
 name: release
 kind: pipeline
 type: docker
@@ -701,6 +802,7 @@ depends_on:
   - E2E Tests on kind clusters version 1.32.2
   - E2E Tests on kind clusters version 1.33.0
   - E2E Tests on kind clusters version 1.34.0
+  - E2E Tests on kind clusters version 1.35.0
 
 platform:
   os: linux

--- a/.drone.yml
+++ b/.drone.yml
@@ -715,7 +715,7 @@ environment:
   KUBECONFIG: "kubeconfig-e2e"
 
   # Tool versions
-  KUBECTL_VERSION: "1.35.0"
+  KUBECTL_VERSION: "1.35.5"
 
 volumes:
   - name: dockersock

--- a/katalog/dex/MAINTENANCE.md
+++ b/katalog/dex/MAINTENANCE.md
@@ -17,6 +17,7 @@ With the `dex-built.yml` file, check differences with the current `deploy.yml` f
 What was customized (what differs from the helm template command):
 
 - Simplified the labels
+- Kept config volume mounted at `/etc/dex/cfg` (now chart default is `/etc/dex`) to allow other volumes under `/etc/dex/` (e.g. TLS CA at `/etc/dex/tls/`)
 - Changed metrics port name from `telemetry` to `metrics`
 - Simplified container command
 - Changed configuration path

--- a/katalog/dex/README.md
+++ b/katalog/dex/README.md
@@ -16,7 +16,7 @@ You can use Dex for example to provide OIDC authentication using users from an L
 ## Image repository and tag
 
 - Dex repository: <https://github.com/dexidp/dex>
-- Dex container image: `registry.sighup.io/fury/dexidp/dex:v2.44.0`
+- Dex container image: `registry.sighup.io/fury/dexidp/dex:v2.45.1`
 
 ## Configuration
 

--- a/katalog/dex/deploy.yml
+++ b/katalog/dex/deploy.yml
@@ -110,11 +110,11 @@ spec:
                 - ALL
       containers:
         - name: dex
-          image: ghcr.io/dexidp/dex:v2.44.0
+          image: ghcr.io/dexidp/dex:v2.45.1
           command:
             - /usr/local/bin/dex
             - serve
-            - /etc/dex/cfg/config.yml
+            - /etc/dex/config.yaml
           ports:
             - name: http
               containerPort: 5556
@@ -149,7 +149,7 @@ spec:
                 - ALL
           volumeMounts:
             - name: config
-              mountPath: /etc/dex/cfg
+              mountPath: /etc/dex
               readOnly: true
             - name: dex-web-custom-archive
               mountPath: /web-archive

--- a/katalog/dex/deploy.yml
+++ b/katalog/dex/deploy.yml
@@ -114,7 +114,7 @@ spec:
           command:
             - /usr/local/bin/dex
             - serve
-            - /etc/dex/config.yaml
+            - /etc/dex/cfg/config.yml
           ports:
             - name: http
               containerPort: 5556
@@ -149,7 +149,7 @@ spec:
                 - ALL
           volumeMounts:
             - name: config
-              mountPath: /etc/dex
+              mountPath: /etc/dex/cfg
               readOnly: true
             - name: dex-web-custom-archive
               mountPath: /web-archive

--- a/katalog/dex/kustomization.yaml
+++ b/katalog/dex/kustomization.yaml
@@ -17,4 +17,4 @@ images:
     newName: registry.sighup.io/fury/busybox
   - name: ghcr.io/dexidp/dex
     newName: registry.sighup.io/fury/dexidp/dex
-    newTag: v2.44.0
+    newTag: v2.45.1

--- a/katalog/gangplank/README.md
+++ b/katalog/gangplank/README.md
@@ -16,7 +16,7 @@ Kubernetes supports OpenID Connect Tokens as a way to identify users who access 
 ## Image repository and tag
 
 - Gangplank repository: <https://github.com/sighupio/gangplank>
-- Gangplank container image: `registry.sighup.io/fury/gangplank:1.1.1`
+- Gangplank container image: `registry.sighup.io/fury/gangplank:1.2.0`
 
 ## Configuration
 

--- a/katalog/gangplank/kustomization.yaml
+++ b/katalog/gangplank/kustomization.yaml
@@ -15,4 +15,4 @@ configMapGenerator:
 
 images:
   - name: registry.sighup.io/fury/gangplank
-    newTag: "1.1.1"
+    newTag: "1.2.0"

--- a/katalog/pomerium/kustomization.yaml
+++ b/katalog/pomerium/kustomization.yaml
@@ -52,4 +52,4 @@ vars:
 images:
   - name: pomerium/pomerium
     newName: registry.sighup.io/fury/pomerium/pomerium
-    newTag: nonroot-v0.31.1
+    newTag: nonroot-v0.32.7

--- a/mise.toml
+++ b/mise.toml
@@ -4,20 +4,20 @@
 
 [env]
 # Default values for local development
-KUBE_VERSION = "1.34.0"
+KUBE_VERSION = "1.35.0"
 DRONE_BUILD_NUMBER = "9999"
 DRONE_REPO_NAME = "module-auth"
 
 [tools]
-kind = "0.30.0"    
-kubectl = "1.34.2" 
+kind = "0.31.0"
+kubectl = "1.35.0"
 kustomize = "5.6.0"
 helm = "3.15.0"    
 yq = "4.43.1"      
 go = "1.23"        
 bats = "1.11.0"    
 drone = "1.9.0"
-kapp = "0.64.2"
+kapp = "0.65.3"
 "ubi:google/addlicense" = "v1.1.1"
 envsubst = "1.4.3"
 dyff = "1.9.0"

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ DRONE_REPO_NAME = "module-auth"
 
 [tools]
 kind = "0.31.0"
-kubectl = "1.35.0"
+kubectl = "1.35.5"
 kustomize = "5.6.0"
 helm = "3.15.0"    
 yq = "4.43.1"      


### PR DESCRIPTION
### Summary 💡

Updates Gangplank  to v1.2.0, and test it against 1.35

Depends on #50

### Breaking Changes 💔

- None

### Tests performed 🧪

- [x] complete e2e test with auth flow

