### PR TITLE
docs: refactor module documentation, drop legacy Furyfile flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 ![License](https://img.shields.io/github/license/sighupio/module-auth?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
-<!-- <KFD-DOCS> -->
+<!-- <SD-DOCS> -->
 
-**Auth Module** provides Authentication Management for [SIGHUP Distribution (SD)][skd-repo].
+**Auth Module** provides authentication and access management for [SIGHUP Distribution (SD)][kfd-repo].
 
-If you are new to SD please refer to the [official documentation][skd-docs] on how to get started with the distribution.
+If you are new to SD please refer to the [official documentation][kfd-docs] on how to get started with SD.
 
 ## Overview
 
@@ -25,13 +25,15 @@ If you are new to SD please refer to the [official documentation][skd-docs] on h
 
 ## Packages
 
-Auth Module provides the following packages:
+The following packages are included in Auth Module:
 
 | Package                        | Version   | Description                                                               |
 | ------------------------------ | --------- | ------------------------------------------------------------------------- |
 | [Pomerium](katalog/pomerium)   | `v0.32.7` | Identity-aware proxy that enables secure access to internal applications. |
 | [Dex](katalog/dex)             | `v2.45.1` | Dex is a Federated OpenID Connect Provider.                               |
-| [Gangplank](katalog/gangplank) | `v1.2.0`  | Enable authentication flows via OIDC for a kubernetes cluster.            |
+| [Gangplank](katalog/gangplank) | `v1.2.0`  | Enable authentication flows via OIDC for a Kubernetes cluster.            |
+
+Click on each package to see its full documentation.
 
 ## Compatibility
 
@@ -45,129 +47,66 @@ Auth Module provides the following packages:
 | `1.34.x`           | :white_check_mark: | No known issues. |
 | `1.35.x`           | :white_check_mark: | No known issues. |
 
-Check the [compatibility matrix][compatibility-matrix] for additional information on previous releases of the modules.
+Check the [compatibility matrix][compatibility-matrix] for additional information about previous releases of the modules.
 
 ## Usage
 
+**Auth Module** is part of SIGHUP Distribution (SD) and is deployed automatically by [`furyctl`][furyctl-repo] when you create or update a cluster. You don't need to download, vendor or install its packages manually.
 
-> [!NOTE]
-> Instructions below are for deploying the module using furyctl legacy, that required manual intervention.
->
-> Latest versions of furyctl automate the whole process and it is recommended to use the latest version of furyctl instead.
+### Configuration
 
-### Prerequisites
-
-| Tool                        | Version   | Description                                                                                                                                                    |
-| --------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [furyctl][furyctl-repo]     | `>=0.6.0` | The recommended tool to download and manage SD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
-| [kustomize][kustomize-repo] | `>=3.5.0` | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
-
-### Deployment with legacy furyctl
-
-1. List the packages you want to deploy and their version in a `Furyfile.yml`:
+The module is deployed with sensible defaults. Configuration is **optional**: you can customize its packages under `spec.distribution.modules.auth` in your `furyctl.yaml`. If you omit the block, the defaults are applied.
 
 ```yaml
-versions:
-  auth: "v0.7.0"
-bases:
-  - name: auth/pomerium
-  - name: auth/dex
-  - name: auth/gangplank
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
+spec:
+  distribution:
+    modules:
+      auth:
+        baseDomain: example.dev
+        provider:
+          type: sso
+        dex:
+          connectors:
+            - type: ldap
+              id: ldap
+              name: LDAP
+              # connector-specific configuration
+        pomerium: {}
 ```
 
-> See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
+See the configuration reference for your cluster kind for the full list of available options: [EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd] or [OnPremises][schema-reference-onprem].
 
-2. Execute `furyctl vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/auth/`.
-
-4. Define a `kustomization.yaml` that includes the `./vendor/katalog/auth` directory as a resource.
-
-```yaml
-resources:
-  - ./vendor/katalog/auth/pomerium
-  - ./vendor/katalog/auth/dex
-  - ./vendor/katalog/auth/gangplank
-```
-
-5. Create the configuration file for Dex ([here's an LDAP-based example](katalog/dex/config.yml)) and add it as a secret to the `kustomization.yaml` file, like this:
-
-```yaml
-secretGenerator:
-  - name: dex
-    namespace: kube-system
-    files:
-      - config.yml=./secrets/dex/config.yml
-```
-
-> ℹ️ read more on [Dex's readme](katalog/dex/README.md).
-
-⛔️ Before proceeding, follow the instructions in [Pomerium's package readme](katalog/pomerium/README.md) and [Gangplank's readme](katalog/gangplank/README.md) to configure them.
-
-6. Finally, to deploy the module to your cluster, execute:
-
-```bash
-kustomize build . | kubectl apply -f -
-```
-
-### Monitoring
-
-SD Auth module integrates out-of-the-box with SD's Monitoring module. Providing metrics and dashboards to visualize the status of its components.
-
-In particular:
-
-- Dex exposes standard Go adapter metrics, the metrics are automatically scrapped by Prometheus when using SD Monitoring module but there are no Grafana dashboards nor alerts defined.
-- Pomerium exposes several metrics about Pomerium itself and its underlying envoy proxy. Metrics are scrapped automatically by Prometheus and 2 Grafana dashboards are available with the `pomerium` tag when using SD Monitoring module. Here are some screenshots:
-
-<!-- markdownlint-disable MD033 -->
-
-<a href="docs/images/screenshots/pomerium-dashboard.png"><img src="docs/images/screenshots/pomerium-dashboard.png" width="250"/></a>
-<a href="docs/images/screenshots/pomerium-envoy-dashboard.png"><img src="docs/images/screenshots/pomerium-envoy-dashboard.png" width="250"/></a>
-
-<!-- markdownlint-enable MD033 -->
-
-### Screenshots
-
-<!-- markdownlint-disable MD033 -->
-
-- Dex Login:
-
-<a href="docs/images/screenshots/dex.png"><img src="docs/images/screenshots/dex.png" width="250"/></a>
-
-- Pomerium 403 not authorized error screen:
-
-<a href="docs/images/screenshots/pomerium-403.png"><img src="docs/images/screenshots/pomerium-403.png" width="250"/></a>
-
-- Pomerium user profile screen:
-
-<a href="docs/images/screenshots/pomerium-userprofile.png"><img src="docs/images/screenshots/pomerium-userprofile.png" width="250"/></a>
-
-<!-- markdownlint-enable MD033 -->
+To install SD from scratch, follow the [Getting started][getting-started] guide.
 
 <!-- Links -->
 
+[kfd-repo]: https://github.com/sighupio/distribution
 [furyctl-repo]: https://github.com/sighupio/furyctl
-[skd-repo]: https://github.com/sighupio/distribution
-[kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
-[skd-docs]: https://docs.kubernetesfury.com/docs/distribution/
-[compatibility-matrix]: https://github.com/sighupio/module-auth/blob/master/docs/COMPATIBILITY_MATRIX.md
+[kfd-docs]: https://docs.sighup.io/docs/distribution/
 [pomerium-repo]: https://github.com/pomerium/pomerium
 [dex-repo]: https://github.com/dexidp/dex
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesauth
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesauth
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesauth
+[getting-started]: https://docs.sighup.io/docs/getting-started/
+[compatibility-matrix]: https://github.com/sighupio/module-auth/blob/main/docs/COMPATIBILITY_MATRIX.md
 
-<!-- </KFD-DOCS> -->
+<!-- </SD-DOCS> -->
 
 <!-- <FOOTER> -->
 
 ## Contributing
 
-Before contributing, please read first the [Contributing Guidelines](docs/CONTRIBUTING.md).
+Before contributing, please read first the [Contributing Guidelines](https://github.com/sighupio/distribution/blob/main/docs/CONTRIBUTING.md).
 
 ### Reporting Issues
 
-In case you experience any problems with the module, please [open a new issue](https://github.com/sighupio/module-auth/issues/new/choose).
+In case you experience any problem with the module, please [open a new issue](https://github.com/sighupio/module-auth/issues/new/choose).
 
 ## License
 
-This module is open-source and it's released under the following [LICENSE](LICENSE)
+This module is open-source and it's released under the following [LICENSE](LICENSE).
 
 <!-- </FOOTER> -->

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 ### Configuration
 
-The module is deployed with sensible defaults. Configuration is **optional**: you can customize its packages under `spec.distribution.modules.auth` in your `furyctl.yaml`. If you omit the block, the defaults are applied.
+You configure the module under `spec.distribution.modules.auth` in your `furyctl.yaml`. The `provider.type` field selects how access to the cluster's internal applications is protected: `none` (no added authentication, the default), `basicAuth`, or `sso` (Pomerium + Dex). The other fields are optional and fall back to sensible defaults.
 
 ```yaml
 apiVersion: kfd.sighup.io/v1alpha2

--- a/katalog/dex/README.md
+++ b/katalog/dex/README.md
@@ -1,45 +1,30 @@
 # Dex
 
-<!-- <KFD-DOCS> -->
+<!-- <SD-DOCS> -->
 
-Dex is an identity service that uses OpenID Connect to drive authentication for other apps.
+## Overview
 
-You can use Dex for example to provide OIDC authentication using users from an LDAP backend.
+Dex is an identity service that uses OpenID Connect to drive authentication for other apps. In the Auth Module it acts as the OIDC provider, federating authentication to upstream identity sources (for example an LDAP backend) so that users can sign in to internal applications and to the cluster.
 
-> ℹ️ Learn more about Dex in [the official documentation](https://dexidp.io/docs/getting-started/).
+## Upstream project
 
-## Requirements
-
-- Kubernetes >= `1.24.0`
-- Kustomize >= `v3`
-
-## Image repository and tag
-
-- Dex repository: <https://github.com/dexidp/dex>
-- Dex container image: `registry.sighup.io/fury/dexidp/dex:v2.45.1`
-
-## Configuration
-
-Dex is deployed with the following default configuration:
-
-- Replica number: `1`
-- Listens on port `5556`
-- Resource limits are `250m` for CPU and `200Mi` for memory
-
-Dex is configured using a `config.yml` file. You can get [a sample file from the official docs](https://github.com/dexidp/dex/blob/v2.20.0/examples/config-dev.yaml) or check out the [provided LDAP-based example configuration file](example/config.yml)
-
-Once you have written the configuration file for your environment, create a Kubernetes secret named `dex` in the `kube-system` namespace with the contents of the file under the `config.yml` key.
-
-> ℹ️ We recommend you do this using Kustomize, either with a `secretGenerator` or as a resource.
-
-The `dex` secret will then be mounted by the deployment as a volume in the right path.
+This package is based on the upstream [Dex][dex-github].
 
 ## Deployment
 
-Once you have created the configuration file, you can deploy Dex by running the following command in the folder of this package:
+This package is deployed as part of **Auth Module** when you create a cluster with `furyctl`.
 
-```shell
-kustomize build | kubectl apply -f -
-```
+You can customize it under `spec.distribution.modules.auth.dex` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
-<!-- </KFD-DOCS> -->
+<!-- Links -->
+
+[dex-github]: https://github.com/dexidp/dex
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesauth
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesauth
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesauth
+
+<!-- </SD-DOCS> -->
+
+## License
+
+For license details please see [LICENSE](../../LICENSE)

--- a/katalog/gangplank/README.md
+++ b/katalog/gangplank/README.md
@@ -1,45 +1,30 @@
 # Gangplank
 
-<!-- <KFD-DOCS> -->
+<!-- <SD-DOCS> -->
 
-Gangplank is an application that can be used to easily enable authentication flows via OIDC for a Kubernetes cluster.
+## Overview
 
-Kubernetes supports OpenID Connect Tokens as a way to identify users who access the cluster. Gangplank allows users to self-configure their kubectl configuration in a few short steps.
+Gangplank is an application that enables authentication flows via OIDC for a Kubernetes cluster. Kubernetes supports OpenID Connect tokens to identify users who access the cluster, and Gangplank lets users self-configure their `kubectl` configuration in a few short steps using the cluster's Dex provider.
 
-> ℹ️ Learn more about Gangplank in the [official repository](https://github.com/sighupio/gangplank) and in the [official documentation](https://github.com/sighupio/gangplank/blob/main/docs/README.md).
+## Upstream project
 
-## Requirements
-
-- Kubernetes >= `1.18.0`
-- Kustomize = `v3.5.3`
-
-## Image repository and tag
-
-- Gangplank repository: <https://github.com/sighupio/gangplank>
-- Gangplank container image: `registry.sighup.io/fury/gangplank:1.2.0`
-
-## Configuration
-
-Gangplank is configured using a `gangplank.yml` file. You can find a [sample configuration file here](example/gangplank.yml).
-
-Notice that to enable Gangplank to communicate with Dex you need to add the required configuration under `staticClients` section.
-
-Once you have written your configuration file, create a Kubernetes secret named `gangplank` in the `kube-system` namespace with the contents of the configuration file under the `gangplank.yml` key.
-
-> ℹ️ We recommend you do this using Kustomize, either with a `secretGenerator` or as a resource.
-
-The `gangplank` secret will then be mounted by the deployment as a volume in the right path.
+This package is based on the upstream [Gangplank][gangplank-github].
 
 ## Deployment
 
-Once you have created the configuration file, you can deploy Gangplank by running the following command in the folder of this package:
+This package is deployed as part of **Auth Module** when you create a cluster with `furyctl`.
 
-```shell
-kustomize build | kubectl apply -f -
-```
+You can customize it under `spec.distribution.modules.auth` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
+
+<!-- Links -->
+
+[gangplank-github]: https://github.com/sighupio/gangplank
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesauth
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesauth
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesauth
+
+<!-- </SD-DOCS> -->
 
 ## License
 
-For license details please see [LICENSE](https://sighup.io/fury/license)
-
-<!-- </KFD-DOCS> -->
+For license details please see [LICENSE](../../LICENSE)

--- a/katalog/pomerium/README.md
+++ b/katalog/pomerium/README.md
@@ -1,95 +1,30 @@
 # Pomerium
 
-<!-- <KFD-DOCS> -->
+<!-- <SD-DOCS> -->
 
-Pomerium is an identity-aware proxy that enables secure access to internal applications. Pomerium provides a standardized interface to add access control to applications regardless of whether the application itself has authorization or authentication baked-in
+## Overview
 
-## Pomerium Setup
+Pomerium is an identity-aware proxy that enables secure access to internal applications. It provides a standardized way to add access control to applications regardless of whether the application itself has authorization or authentication baked in. In the Auth Module it sits in front of internal ingresses and delegates authentication to Dex.
 
-This document is intended to give a brief overview of how Pomerium can be implemented, for further details, please look at the [official documentation][pomerium-docs].
+## Upstream project
 
-### Deploy
+This package is based on the upstream [Pomerium][pomerium-github].
 
-The base kustomization file present [here](./kustomization.yaml) allows you to quickly integrate Pomerium in proxy auth mode with an existing Dex service that could, for example, be connected to an LDAP backend.
+## Deployment
 
-To do so, you will need to edit your Dex configuration, adding a static client to be used by Pomerium, like in the example below:
+This package is deployed as part of **Auth Module** when you create a cluster with `furyctl`.
 
-```yaml
->>staticClients:
-    - id: "pomerium-auth-client"
-      secret: "your-super-secret"
-      name: "Pomerium"
-      redirectURIs:
-       - "https://pomerium.example.com/oauth2/callback"
-```
-
-> ⚠️ Configure the `redirectURIs` section accordingly to the hosts used for the pomerium ingress.
-<!-- space intentionally left blank -->
-> See [Dex official documentation][dex-docs] for more details.
-
-Once Dex is configured correctly, you will need to override the configuration example ([policy](./config/policy.example.yaml) and environment variables via a [configmap](./config/config.example.env) and [secret](secrets/pomerium.example.env)) in your `kustomization.yaml` file like in the example below:
-
-```yaml
-configMapGenerator:
-  - name: pomerium-policy
-    behavior: replace
-    files:
-      - policy.yml=config/pomerium-policy.yml
-  - name: pomerium
-    behavior: replace
-    envs:
-      - config/pomerium-config.env
-
-secretGenerator:
-  - name: pomerium-env
-    behavior: replace
-    envs:
-      - secrets/pomerium.env
-```
-
-> 💡 You can copy the examples in the module (see [1](config/config.example.env), [2](config/policy.example.yaml), and [3](secrets/pomerium.example.env)) and override them according to your settings.
-
-**⚠ WARNING: in the policy file, you'll need to set up a route for each ingress you want to protect with Pomerium authorization service.**
-
-### Ingresses
-
-Once Pomerium and Dex are correctly configured, the last step is to create an Ingress with the hostname to expose your application **in Pomerium's namespace** pointing to Pomerium's service, for example:
-
-```yaml
----
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
-  annotations:
-    forecastle.stakater.com/expose: "true"
-    forecastle.stakater.com/appName: "Prometheus"
-    forecastle.stakater.com/icon: "https://github.com/stakater/ForecastleIcons/raw/master/prometheus.png"
-    kubernetes.io/tls-acme: "true"
-
-  name: prometheus
-  namespace: pomerium
-spec:
-  ingressClassName: internal  # or external, or nginx.
-  rules:
-    - host: prometheus.example.com
-      http:
-        paths:
-          - path: /
-            backend:
-              service:
-                name: pomerium  # notice: pomerium, not prometheus
-                port:
-                  name: http
-  tls:
-    - hosts:
-        - prometheus.example.com
-      secretName: prometheus-tls
-```
-
-Now if you access `http(s)://prometheus.example.com` you'll be forwarded to the Dex login page and if the user is authorized the application will be proxied by Pomerim accordingly with the rules set in your policy.
+You can customize it under `spec.distribution.modules.auth.pomerium` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
-[pomerium-docs]: https://www.pomerium.io/docs/
-[dex-docs]: https://dexidp.io/docs/kubernetes/
 
-<!-- </KFD-DOCS> -->
+[pomerium-github]: https://github.com/pomerium/pomerium
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesauth
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesauth
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesauth
+
+<!-- </SD-DOCS> -->
+
+## License
+
+For license details please see [LICENSE](../../LICENSE)


### PR DESCRIPTION
### Summary 💡

This PR replicates the documentation refactor defined in `module-aws` (#104) on this module: the docs are now furyctl/SD-centric and the legacy `Furyfile.yml` + `furyctl legacy vendor` + `kustomize build | kubectl apply` workflow has been removed.

The motivation: this documentation ends up on docs.sighup.io but still described the old legacy workflow and exposed internal implementation details (kustomize patches, raw manifests, image coordinates) that don't make sense on a public docs site.

Relates: sighupio/module-aws#104

### Description 📝

- **`README.md` (SD-DOCS block)**: removed the legacy `Usage`/`Prerequisites`/deployment sections. New `Usage` section explains the module is deployed automatically as part of SD by `furyctl`, with an optional `furyctl.yaml` (`spec.distribution.modules.auth`) example and links to the configuration schema reference (EKSCluster / KFDDistribution / OnPremises) and the getting-started guide.
- **`katalog/*/README.md`**: rewritten to the shared template (Overview → Upstream project → Deployment → License). Removed kustomize/`kubectl apply` instructions, raw manifests, image coordinates and tool prerequisites. Renamed the legacy `KFD-DOCS` markers to `SD-DOCS` and updated the docs links to `docs.sighup.io`.

### Breaking Changes 💔

None, documentation only.

### Tests performed 🧪

- [x] No `Furyfile` / `furyctl legacy vendor` / `kustomize build | kubectl apply` references left inside the `SD-DOCS` blocks
- [x] `SD-DOCS` / `FOOTER` markers intact, no orphan reference links
- [x] `furyctl.yaml` snippet fields match the v1alpha2 schema (`spec.distribution.modules.auth`)
- [x] Visual review of the GitHub markdown rendering

### Future work 🔧

- Replicate the same template on the remaining modules.