### PR TITLE
ci: introduce manifest testing with kube-linter

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,16 +9,26 @@ node:
   performance: low
 clone:
   depth: 1
+volumes:
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
 steps:
   - name: check
-    image: docker.io/library/golang:1.21
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: mise-cache
+        path: /mise-data
     commands:
-      - go install github.com/google/addlicense@v1.1.1
-      - addlicense -c "SIGHUP s.r.l" -v -l bsd -y "2017-present" --check .
+      - mise run check-license
 
 ---
-name: Linting
+name: validate
 kind: pipeline
 type: docker
 node:
@@ -34,15 +44,13 @@ platform:
 environment:
   # Mise configuration
   MISE_DATA_DIR: "/mise-data"
-  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
-
 volumes:
   - name: mise-cache
     host:
       path: /root/mise_data_dir
 steps:
-  - name: Render Manifests
-    image: quay.io/sighup/mise:v2025.4.4
+  - name: render
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     environment:
       GITHUB_TOKEN:
@@ -53,19 +61,32 @@ steps:
     depends_on:
       - clone
     commands:
-      - |
-        mise use kustomize@5.6.0
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       - kustomize build katalog/pomerium > pomerium.yml
       - kustomize build katalog/dex > dex.yml
       - kustomize build katalog/gangplank > gangplank.yml
+
+  - name: lint
+    image: quay.io/sighup/mise:v2026.6.14
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: mise-cache
+        path: /mise-data
+    depends_on:
+      - render
+    commands:
+      - mise run lint
 
   - &check-deprecated-apis
     name: check-deprecated-apis-pomerium
     image: us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5
     pull: always
     depends_on:
-      - Render Manifests
+      - lint
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
       - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.35.0
@@ -91,7 +112,7 @@ platform:
   os: linux
   arch: amd64
 depends_on:
-  - Linting
+  - validate
 clone:
   depth: 1
 trigger:
@@ -102,8 +123,7 @@ trigger:
 environment:
   # Mise configuration
   MISE_DATA_DIR: "/mise-data"
-  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
-  
+
   # Cluster configuration
   KUBE_VERSION: "1.29.8"
   KUBECONFIG: "kubeconfig-e2e"
@@ -121,7 +141,7 @@ volumes:
 
 steps:
   - name: Create Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -141,7 +161,7 @@ steps:
       - ./scripts/create-e2e-cluster.sh
 
   - name: Run E2E Tests
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -161,7 +181,7 @@ steps:
       - ./scripts/run-e2e-tests.sh
 
   - name: Destroy Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -192,7 +212,7 @@ platform:
   os: linux
   arch: amd64
 depends_on:
-  - Linting
+  - validate
 clone:
   depth: 1
 trigger:
@@ -203,8 +223,7 @@ trigger:
 environment:
   # Mise configuration
   MISE_DATA_DIR: "/mise-data"
-  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
-  
+
   # Cluster configuration
   KUBE_VERSION: "1.30.4"
   KUBECONFIG: "kubeconfig-e2e"
@@ -222,7 +241,7 @@ volumes:
 
 steps:
   - name: Create Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -242,7 +261,7 @@ steps:
       - ./scripts/create-e2e-cluster.sh
 
   - name: Run E2E Tests
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -262,7 +281,7 @@ steps:
       - ./scripts/run-e2e-tests.sh
 
   - name: Destroy Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -293,7 +312,7 @@ platform:
   os: linux
   arch: amd64
 depends_on:
-  - Linting
+  - validate
 clone:
   depth: 1
 trigger:
@@ -304,7 +323,6 @@ trigger:
 environment:
   # Mise configuration
   MISE_DATA_DIR: "/mise-data"
-  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
   
   # Cluster configuration
   KUBE_VERSION: "1.31.0"
@@ -323,7 +341,7 @@ volumes:
 
 steps:
   - name: Create Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -343,7 +361,7 @@ steps:
       - ./scripts/create-e2e-cluster.sh
 
   - name: Run E2E Tests
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -363,7 +381,7 @@ steps:
       - ./scripts/run-e2e-tests.sh
 
   - name: Destroy Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -394,7 +412,7 @@ platform:
   os: linux
   arch: amd64
 depends_on:
-  - Linting
+  - validate
 clone:
   depth: 1
 trigger:
@@ -405,7 +423,6 @@ trigger:
 environment:
   # Mise configuration
   MISE_DATA_DIR: "/mise-data"
-  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
   
   # Cluster configuration
   KUBE_VERSION: "1.32.2"
@@ -424,7 +441,7 @@ volumes:
 
 steps:
   - name: Create Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -444,7 +461,7 @@ steps:
       - ./scripts/create-e2e-cluster.sh
 
   - name: Run E2E Tests
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -464,7 +481,7 @@ steps:
       - ./scripts/run-e2e-tests.sh
 
   - name: Destroy Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -495,7 +512,7 @@ platform:
   os: linux
   arch: amd64
 depends_on:
-  - Linting
+  - validate
 clone:
   depth: 1
 trigger:
@@ -506,7 +523,6 @@ trigger:
 environment:
   # Mise configuration
   MISE_DATA_DIR: "/mise-data"
-  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
   
   # Cluster configuration
   KUBE_VERSION: "1.33.0"
@@ -525,7 +541,7 @@ volumes:
 
 steps:
   - name: Create Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -545,7 +561,7 @@ steps:
       - ./scripts/create-e2e-cluster.sh
 
   - name: Run E2E Tests
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -565,7 +581,7 @@ steps:
       - ./scripts/run-e2e-tests.sh
 
   - name: Destroy Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -596,7 +612,7 @@ platform:
   os: linux
   arch: amd64
 depends_on:
-  - Linting
+  - validate
 clone:
   depth: 1
 trigger:
@@ -607,7 +623,6 @@ trigger:
 environment:
   # Mise configuration
   MISE_DATA_DIR: "/mise-data"
-  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
 
   # Cluster configuration
   KUBE_VERSION: "1.34.0"
@@ -626,7 +641,7 @@ volumes:
 
 steps:
   - name: Create Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -646,7 +661,7 @@ steps:
       - ./scripts/create-e2e-cluster.sh
 
   - name: Run E2E Tests
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -666,7 +681,7 @@ steps:
       - ./scripts/run-e2e-tests.sh
 
   - name: Destroy Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -697,7 +712,7 @@ platform:
   os: linux
   arch: amd64
 depends_on:
-  - Linting
+  - validate
 clone:
   depth: 1
 trigger:
@@ -708,7 +723,6 @@ trigger:
 environment:
   # Mise configuration
   MISE_DATA_DIR: "/mise-data"
-  MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
 
   # Cluster configuration
   KUBE_VERSION: "1.35.0"
@@ -727,7 +741,7 @@ volumes:
 
 steps:
   - name: Create Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -747,7 +761,7 @@ steps:
       - ./scripts/create-e2e-cluster.sh
 
   - name: Run E2E Tests
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -767,7 +781,7 @@ steps:
       - ./scripts/run-e2e-tests.sh
 
   - name: Destroy Kind Cluster
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     network_mode: host
     depends_on:
@@ -819,7 +833,7 @@ steps:
   - name: prepare-tar-gz
     image: alpine:latest
     pull: always
-    depends_on: [clone]
+    depends_on: [ clone ]
     commands:
       - tar -zcvf fury-kubernetes-auth-${DRONE_TAG}.tar.gz katalog/ LICENSE README.md
     when:
@@ -830,7 +844,7 @@ steps:
   - name: prepare-release-notes
     image: quay.io/sighup/fury-release-notes-plugin:3.7_2.8.4
     pull: always
-    depends_on: [clone]
+    depends_on: [ clone ]
     settings:
       release_notes_file_path: release-notes.md
     when:

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+checks:
+  doNotAutoAddDefaults: false
+  include:
+    - exposed-services
+    - use-namespace
+  exclude:
+    - job-ttl-seconds-after-finished
+    - no-read-only-root-fs
+    - pdb-unhealthy-pod-eviction-policy
+    - privilege-escalation-container
+    - privileged-container
+    - run-as-non-root
+    - unset-cpu-requirements
+    - unset-memory-requirements

--- a/mise.toml
+++ b/mise.toml
@@ -9,18 +9,18 @@ DRONE_BUILD_NUMBER = "9999"
 DRONE_REPO_NAME = "module-auth"
 
 [tools]
-kind = "0.31.0"
-kubectl = "1.35.5"
-kustomize = "5.6.0"
-helm = "3.15.0"    
-yq = "4.43.1"      
-go = "1.23"        
-bats = "1.11.0"    
+bats = "1.11.0"
 drone = "1.9.0"
-kapp = "0.65.3"
-"ubi:google/addlicense" = "v1.1.1"
-envsubst = "1.4.3"
 dyff = "1.9.0"
+envsubst = "1.4.3"
+helm = "3.15.0"
+kapp = "0.65.3"
+kind = "0.32.0"
+kube-linter = "0.8.3"
+kubectl = "1.35.6"
+kustomize = "5.6.0"
+yq = "4.53.3"
+"ubi:google/addlicense" = "v1.1.1"
 
 # Development task definitions
 [tasks.add-license]
@@ -29,6 +29,14 @@ run = '''
 echo "📄 Adding license headers..."
 addlicense -c "SIGHUP s.r.l" -y "2017-present" -v -l bsd .
 echo "✅ License headers added!"
+'''
+
+[tasks.check-license]
+description = "Check that all files have license headers"
+run = '''
+echo "🔍 Checking license headers..."
+addlicense -c "SIGHUP s.r.l" -y "2017-present" -v -l bsd --check .
+echo "✅ All files have license headers!"
 '''
 
 [tasks.validate-manifests]
@@ -42,6 +50,13 @@ kustomize build katalog/tests/manifests > /dev/null && echo "  ✅ complete auth
 echo "✅ All manifests validated!"
 '''
 
+[tasks.lint]
+description = "Lint all katalog manifests with kube-linter"
+run = '''
+echo "🔍 Linting katalog/ with kube-linter..."
+kube-linter lint --config .kube-linter.yaml katalog/
+echo "✅ All manifests passed linting!"
+'''
 
 [tasks.e2e-create-cluster]
 description = "Create Kind cluster for E2E testing"


### PR DESCRIPTION
### Summary 💡

Introduce manifest checks with [kube-linter](https://github.com/stackrox/kube-linter).

### Description 📝

This new tool, when it detects a folder containing a kustomization file automatically processes it and scans the output.
I added the new step to the CI.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- CI: https://ci.sighup.io/sighupio/module-auth/430
- I tested that adding a forbidden lint like an image with latest tag then the task fails

### Future work 🔧

Not planned.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] ~~I've updated the `docs/releases/unreleased.md` file (or equivalent)~~
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green